### PR TITLE
add existing pvc

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: n8n
 description: A N8N Helm chart for Kubernetes. n8n is a free and open fair-code licensed node-based Workflow Automation Tool.
 type: application
-version: 0.136.0
-appVersion: "0.136.0"
+version: 0.137.0
+appVersion: "0.137.0"
 
 keywords:
 - n8n

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -83,6 +83,9 @@ spec:
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ include "n8n.fullname" . }}
+          {{- else if .Values.persistence.existing }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existing.name }}
           {{- else }}
           emptyDir: {}
           {{- end }}


### PR DESCRIPTION
## Description
add existing pvc

## Diff
```
evm-internal, n8n-evercrm, Deployment (apps) has changed:
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    labels:
      app.kubernetes.io/instance: n8n-evercrm
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: n8n
-     app.kubernetes.io/version: 0.136.0
-     helm.sh/chart: n8n-0.136.0
-     helm.toolkit.fluxcd.io/name: n8n-evercrm
-     helm.toolkit.fluxcd.io/namespace: evm-internal
+     app.kubernetes.io/version: 0.137.0
+     helm.sh/chart: n8n-0.137.0
    name: n8n-evercrm
  spec:
    replicas: 1
    selector:
      matchLabels:
        app.kubernetes.io/instance: n8n-evercrm
        app.kubernetes.io/name: n8n
    strategy:
-     type: RollingUpdate
+     type: Recreate
    template:
      metadata:
        labels:
          app.kubernetes.io/instance: n8n-evercrm
          app.kubernetes.io/name: n8n
      spec:
        affinity:
          nodeAffinity:
            requiredDuringSchedulingIgnoredDuringExecution:
              nodeSelectorTerms:
              - matchExpressions:
                - key: evermos.com/serviceClass
                  operator: In
                  values:
                  - internal-tier-one
                - key: karpenter.sh/capacity-type
                  operator: In
                  values:
                  - on-demand
        containers:
        - command:
          - n8n
          env:
          - name: DB_TYPE
            value: postgresdb
          - name: EXECUTIONS_DATA_MAX_AGE
            value: "168"
          - name: EXECUTIONS_DATA_PRUNE
            value: "false"
          - name: EXECUTIONS_DATA_SAVE_MANUAL_EXECUTIONS
            value: "false"
          - name: EXECUTIONS_DATA_SAVE_ON_ERROR
            value: all
          - name: EXECUTIONS_DATA_SAVE_ON_PROGRESS
            value: "false"
          - name: EXECUTIONS_DATA_SAVE_ON_SUCCESS
            value: all
          - name: EXECUTIONS_MODE
            value: queue
          - name: EXECUTIONS_TIMEOUT
            value: "900"
          - name: GENERIC_TIMEZONE
            value: Asia/Jakarta
          - name: N8N_EMAIL_MODE
            value: smtp
          - name: N8N_LOG_LEVEL
            value: debug
          - name: N8N_METRICS
            value: "true"
          - name: N8N_METRICS_PREFIX
            value: n8n_evercrm
          - name: N8N_PORT
            value: "5678"
          - name: QUEUE_BULL_REDIS_DB
            value: "1"
          - name: QUEUE_BULL_REDIS_HOST
            value: redis-arm-redis-ha-haproxy.persistence
          - name: VUE_APP_URL_BASE_API
            value: https://n8n-prod-evercrm.evermosa2z.com/
          - name: WEBHOOK_URL
            value: https://n8n-prod-evercrm.evermosa2z.com/
          - name: DB_POSTGRESDB_DATABASE
            valueFrom:
              secretKeyRef:
                key: pg_db
                name: n8n-evercrm-secrets
          - name: DB_POSTGRESDB_HOST
            valueFrom:
              secretKeyRef:
                key: pg_host
                name: n8n-evercrm-secrets
          - name: DB_POSTGRESDB_PASSWORD
            valueFrom:
              secretKeyRef:
                key: pg_password
                name: n8n-evercrm-secrets
          - name: DB_POSTGRESDB_USER
            valueFrom:
              secretKeyRef:
                key: pg_user
                name: n8n-evercrm-secrets
          - name: N8N_ENCRYPTION_KEY
            valueFrom:
              secretKeyRef:
                key: N8N_ENCRYPTION_KEY
                name: n8n-evercrm-secrets
          - name: N8N_SMTP_HOST
            valueFrom:
              secretKeyRef:
                key: SMTP_DOMAIN
                name: n8n-evercrm-secrets
          - name: N8N_SMTP_PASS
            valueFrom:
              secretKeyRef:
                key: SMTP_PASSWORD
                name: n8n-evercrm-secrets
          - name: N8N_SMTP_PORT
            valueFrom:
              secretKeyRef:
                key: SMTP_PORT
                name: n8n-evercrm-secrets
          - name: N8N_SMTP_SENDER
            valueFrom:
              secretKeyRef:
                key: DEFAULT_FROM_EMAIL
                name: n8n-evercrm-secrets
          - name: N8N_SMTP_USER
            valueFrom:
              secretKeyRef:
                key: SMTP_USERNAME
                name: n8n-evercrm-secrets
          - name: QUEUE_BULL_REDIS_PASSWORD
            valueFrom:
              secretKeyRef:
                key: QUEUE_BULL_REDIS_PASSWORD
                name: n8n-evercrm-secrets
          image: n8nio/n8n:0.208.0
          imagePullPolicy: IfNotPresent
          livenessProbe:
            httpGet:
              path: /healthz
              port: http
            initialDelaySeconds: 15
            periodSeconds: 10
          name: n8n
          ports:
          - containerPort: 5678
            name: http
            protocol: TCP
          readinessProbe:
            httpGet:
              path: /healthz
              port: http
            initialDelaySeconds: 15
            periodSeconds: 10
          resources:
            limits:
              cpu: 1000m
              memory: 2000Mi
            requests:
              cpu: 200m
              memory: 512Mi
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
          volumeMounts:
          - mountPath: /home/node
            name: n8n-evercrm
        imagePullSecrets:
        - name: evermos-docker
        securityContext:
          fsGroup: 1000
          fsGroupChangePolicy: OnRootMismatch
          runAsGroup: 1000
          runAsUser: 1000
        serviceAccountName: default
        tolerations:
        - effect: NoSchedule
          key: internal-tier-one
          operator: Equal
          value: "true"
        volumes:
-       - emptyDir: {}
-         name: n8n-evercrm
+       - name: n8n-evercrm
+         persistentVolumeClaim:
+           claimName: pvc-efs-n8n-evercrm

```